### PR TITLE
Refactored to handle an error when a null workflow ID is sent to work…

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaStreamsObservableQueue.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaStreamsObservableQueue.java
@@ -271,7 +271,7 @@ public class KafkaStreamsObservableQueue implements ObservableQueue, Runnable {
         processedRequest.to(apexResponsesTopic, Produced.with(Serdes.String(), responseContainerSerde));
         // Sink Node - Send Error to client
         processedError.to(apexResponsesTopic, Produced.with(Serdes.String(), responseContainerSerde));
-        processedRequest.filter((clientId, response) -> response.isStartedAWorkflow())
+        processedRequest.filter((clientId, response) -> response.isStartedAWorkflow() && response.getResponseEntity() != null)
                  .foreach((client, response) -> threadPool.execute(new WorkflowStatusMonitor(resourceHandler, objectMapper,
                          this, client, (String) response.getResponseEntity())));
         return builder.build();


### PR DESCRIPTION
…flowMonitor

This eliminate the case when a workflow is started, but an error occurred during starting the workflow, in which a workflow ID is not generated. Then the non generated workflow ID (null) is being sent to the workflow monitor and an error occurs